### PR TITLE
some fixes

### DIFF
--- a/ipaddr.c
+++ b/ipaddr.c
@@ -141,7 +141,6 @@ int ipaddr_op( int ifindex, uint32_t addr, uint8_t length, int addF )
 	req.n.nlmsg_type	= addF ? RTM_NEWADDR : RTM_DELADDR;
 	req.ifa.ifa_family	= AF_INET;
 	req.ifa.ifa_index	= ifindex;
-	req.ifa.ifa_prefixlen	= 32;
 	req.ifa.ifa_prefixlen	= length;
 	
 	addr = htonl( addr );

--- a/vrrpd.c
+++ b/vrrpd.c
@@ -1828,7 +1828,7 @@ int main( int argc, char *argv[] )
 	   	 *slash++ = 0;
 	   	/* retrieve prefix length */
 	   	   	length = (uint8_t)atoi(slash);
-	     	 if ((length > 32) || (length < 0)) length = 32;
+	     	 if (length > 32) length = 32;
 	   	 }
 			vrrpd_log(LOG_WARNING, "vrrpd virtual IP %s\n", argv[argc]);
 			uint32_t ipaddr = inet_addr( argv[argc] );

--- a/vrrpd.c
+++ b/vrrpd.c
@@ -964,10 +964,6 @@ static int parse_cmdline( vrrp_rt *vsrv, int argc, char *argv[] )
 			vif->ifname	= strdup( optarg );
 			/* get the ip address */
 			vif->ipaddr	= ifname_to_ip( optarg );
-			if( !vif->ipaddr ){
-				fprintf( stderr, "no interface found!\n" );
-				goto err;
-			}
 			/* get the hwaddr */
 			if( hwaddr_get( vif->ifname, vif->hwaddr
 					, sizeof(vif->hwaddr)) ){
@@ -1123,10 +1119,6 @@ static int chk_min_cfg( vrrp_rt *vsrv )
 	}
 	if( vsrv->vrid == 0 ){
 		fprintf(stderr, "the virtual id must be set!\n");
-		return -1;
-	}
-	if( vsrv->vif.ipaddr == 0 ){
-		fprintf(stderr, "the interface ipaddr must be set!\n");
 		return -1;
 	}
 	/* make vrrp use the native hwaddr and not the virtual one */

--- a/vrrpd.c
+++ b/vrrpd.c
@@ -332,6 +332,27 @@ static u_short in_csum( u_short *addr, int len, u_short csum)
 	return (answer);
 }
 
+
+/****************************************************************
+ NAME	: get_dev_from_ip			00/02/08 06:51:32
+ AIM	:
+ REMARK	:
+****************************************************************/
+static uint32_t ifname_to_ip( char *ifname )
+{
+	struct ifreq	ifr;
+	int		fd	= socket(AF_INET, SOCK_DGRAM, 0);
+	uint32_t	addr	= 0;
+	if (fd < 0) 	return (-1);
+	strncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+	if (ioctl(fd, SIOCGIFADDR, (char *)&ifr) == 0) {
+		struct sockaddr_in *sin = (struct sockaddr_in *)&ifr.ifr_addr;
+		addr = ntohl(sin->sin_addr.s_addr);
+	}
+	close(fd);
+	return addr;
+}
+
 /****************************************************************
  NAME	: get_dev_from_ip			00/02/08 06:51:32
  AIM	:
@@ -941,6 +962,12 @@ static int parse_cmdline( vrrp_rt *vsrv, int argc, char *argv[] )
 			break;
 		case 'i':
 			vif->ifname	= strdup( optarg );
+			/* get the ip address */
+			vif->ipaddr	= ifname_to_ip( optarg );
+			if( !vif->ipaddr ){
+				fprintf( stderr, "no interface found!\n" );
+				goto err;
+			}
 			/* get the hwaddr */
 			if( hwaddr_get( vif->ifname, vif->hwaddr
 					, sizeof(vif->hwaddr)) ){


### PR DESCRIPTION
Commit 515c91c553923705717ead10dad7e21e900b9dd0 just broken entire startup: it removes vif->ipaddr assignment, but chk_min_cfg() checks it later, so daemon unable to start.
So proper way is try to assing from interface and if it fails, continue with empty (source address for VRRP packets will be 0.0.0.0).
Also fixed some warnings found by cppcheck.